### PR TITLE
feat: add gcp-build step to buildpack in GCP

### DIFF
--- a/application-templates/typescript/event/package.json
+++ b/application-templates/typescript/event/package.json
@@ -8,6 +8,7 @@
     "start": "node build/index.js",
     "start:dev": "concurrently -k \"tsc --watch\" \"nodemon -q build/index.js\"",
     "build": "rimraf ./build && tsc",
+    "gcp-build": "tsc",
     "lint": "eslint . --ext .ts",
     "prettier": "prettier --write '**/*.{js,ts}'",
     "test": "jest --config jest.config.cjs",

--- a/application-templates/typescript/job/package.json
+++ b/application-templates/typescript/job/package.json
@@ -8,6 +8,7 @@
     "start": "node build/index.js",
     "start:dev": "concurrently -k \"tsc --watch\" \"nodemon -q build/index.js\"",
     "build": "rimraf ./build && tsc",
+    "gcp-build": "tsc",
     "lint": "eslint . --ext .ts",
     "prettier": "prettier --write '**/*.{js,ts}'",
     "test": "jest --config jest.config.cjs",

--- a/application-templates/typescript/service/package.json
+++ b/application-templates/typescript/service/package.json
@@ -8,6 +8,7 @@
     "start": "node build/index.js",
     "start:dev": "concurrently -k \"tsc --watch\" \"nodemon -q build/index.js\"",
     "build": "rimraf ./build && tsc",
+    "gcp-build": "tsc",
     "lint": "eslint . --ext .ts",
     "prettier": "prettier --write '**/*.{js,ts}'",
     "test": "jest --config jest.config.cjs",


### PR DESCRIPTION
## Link to the Jira issue
[IM-212] https://jira.commercetools.com/browse/IM-212

## Description and context
Cloud run failing to start for typescript application. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Brief description of the solution
Need to add `"gcp-build": "tsc"` in typescript job, service & event package.json to inform buildpack to use `tsc`.
