### PR TITLE
chore: remove port env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
+# Project
+.env
+
 # Dependency directories
 node_modules/
 .dccache
+
 # Build
 dist
 dist-tarballs

--- a/application-templates/javascript/connect.yaml
+++ b/application-templates/javascript/connect.yaml
@@ -3,7 +3,6 @@ deployAs:
     applicationType: service
     endpoint: /service
     configurationType:
-      PORT: standard
       CTP_PROJECT_KEY: secret
       CTP_CLIENT_ID: secret
       CTP_CLIENT_SECRET: secret

--- a/application-templates/javascript/event/src/index.js
+++ b/application-templates/javascript/event/src/index.js
@@ -13,7 +13,7 @@ import { errorMiddleware } from './middleware/error.middleware.js';
 // Read env variables
 readConfiguration();
 
-const PORT = readConfiguration().port || 3000;
+const PORT = 8080;
 
 // Create the express app
 const app = express();
@@ -30,7 +30,7 @@ app.use(errorMiddleware);
 
 // Listen the application
 const server = app.listen(PORT, () => {
-  logger.info(`⚡️[server]: Server is running at http://localhost:${PORT}`);
+  logger.info(`⚡️ Event application listening on port ${PORT}`);
 });
 
 export default server;

--- a/application-templates/javascript/event/src/utils/config.utils.js
+++ b/application-templates/javascript/event/src/utils/config.utils.js
@@ -16,7 +16,6 @@ export const readConfiguration = () => {
     projectKey: process.env.CTP_PROJECT_KEY,
     scope: process.env.CTP_SCOPE,
     region: process.env.CTP_REGION,
-    port: process.env.PORT,
   };
 
   const validationErrors = getValidateMessages(envValidators, envVars);

--- a/application-templates/javascript/event/src/validators/env.validators.js
+++ b/application-templates/javascript/event/src/validators/env.validators.js
@@ -1,6 +1,5 @@
 import {
   optional,
-  standardNaturalNumber,
   standardString,
   standardKey,
   region,
@@ -49,12 +48,6 @@ const envValidators = [
   region(['region'], {
     code: 'InvalidRegion',
     message: 'Not a valid region.',
-    referencedBy: 'environmentVariables',
-  }),
-
-  optional(standardNaturalNumber)(['port'], {
-    code: 'InvalidPort',
-    message: 'Port is optional but should should be a number when provided.',
     referencedBy: 'environmentVariables',
   }),
 ];

--- a/application-templates/javascript/job/src/index.js
+++ b/application-templates/javascript/job/src/index.js
@@ -15,7 +15,7 @@ import { errorMiddleware } from './middleware/error.middleware.js';
 // Read env variables
 readConfiguration();
 
-const PORT = readConfiguration().port || 3000;
+const PORT = 8080;
 
 // Create the express app
 const app = express();
@@ -28,7 +28,7 @@ app.use(errorMiddleware);
 
 // Listen the application
 const server = app.listen(PORT, () => {
-  logger.info(`⚡️[server]: Server is running at http://localhost:${PORT}`);
+  logger.info(`⚡️ Job application listening on port ${PORT}`);
 });
 
 export default server;

--- a/application-templates/javascript/job/src/utils/config.utils.js
+++ b/application-templates/javascript/job/src/utils/config.utils.js
@@ -16,7 +16,6 @@ export const readConfiguration = () => {
     projectKey: process.env.CTP_PROJECT_KEY,
     scope: process.env.CTP_SCOPE,
     region: process.env.CTP_REGION,
-    port: process.env.PORT,
   };
 
   const validationErrors = getValidateMessages(envValidators, envVars);

--- a/application-templates/javascript/job/src/validators/env.validators.js
+++ b/application-templates/javascript/job/src/validators/env.validators.js
@@ -1,6 +1,5 @@
 import {
   optional,
-  standardNaturalNumber,
   standardString,
   standardKey,
   region,
@@ -49,12 +48,6 @@ const envValidators = [
   region(['region'], {
     code: 'InvalidRegion',
     message: 'Not a valid region.',
-    referencedBy: 'environmentVariables',
-  }),
-
-  optional(standardNaturalNumber)(['port'], {
-    code: 'InvalidPort',
-    message: 'Port is optional but should should be a number when provided.',
     referencedBy: 'environmentVariables',
   }),
 ];

--- a/application-templates/javascript/service/src/index.js
+++ b/application-templates/javascript/service/src/index.js
@@ -13,7 +13,7 @@ import { errorMiddleware } from './middleware/error.middleware.js';
 // Read env variables
 readConfiguration();
 
-const PORT = readConfiguration().port || 3000;
+const PORT = 8080;
 
 // Create the express app
 const app = express();
@@ -30,7 +30,7 @@ app.use(errorMiddleware);
 
 // Listen the application
 const server = app.listen(PORT, () => {
-  logger.info(`⚡️[server]: Server is running at http://localhost:${PORT}`);
+  logger.info(`⚡️ Service application listening on port ${PORT}`);
 });
 
 export default server;

--- a/application-templates/javascript/service/src/utils/config.utils.js
+++ b/application-templates/javascript/service/src/utils/config.utils.js
@@ -16,7 +16,6 @@ export const readConfiguration = () => {
     projectKey: process.env.CTP_PROJECT_KEY,
     scope: process.env.CTP_SCOPE,
     region: process.env.CTP_REGION,
-    port: process.env.PORT,
   };
 
   const validationErrors = getValidateMessages(envValidators, envVars);

--- a/application-templates/javascript/service/src/validators/env.validators.js
+++ b/application-templates/javascript/service/src/validators/env.validators.js
@@ -1,6 +1,5 @@
 import {
   optional,
-  standardNaturalNumber,
   standardString,
   standardKey,
   region,
@@ -49,12 +48,6 @@ const envValidators = [
   region(['region'], {
     code: 'InvalidRegion',
     message: 'Not a valid region.',
-    referencedBy: 'environmentVariables',
-  }),
-
-  optional(standardNaturalNumber)(['port'], {
-    code: 'InvalidPort',
-    message: 'Port is optional but should should be a number when provided.',
     referencedBy: 'environmentVariables',
   }),
 ];

--- a/application-templates/typescript/connect.yaml
+++ b/application-templates/typescript/connect.yaml
@@ -3,7 +3,6 @@ deployAs:
     applicationType: service
     endpoint: /service
     configurationType:
-      PORT: standard
       CTP_PROJECT_KEY: secret
       CTP_CLIENT_ID: secret
       CTP_CLIENT_SECRET: secret

--- a/application-templates/typescript/event/src/index.ts
+++ b/application-templates/typescript/event/src/index.ts
@@ -14,7 +14,7 @@ import { errorMiddleware } from './middleware/error.middleware';
 // Read env variables
 readConfiguration();
 
-const PORT = readConfiguration().port || 3000;
+const PORT = 8080;
 
 // Create the express app
 const app: Express = express();
@@ -31,7 +31,7 @@ app.use(errorMiddleware);
 
 // Listen the application
 const server = app.listen(PORT, () => {
-  logger.info(`⚡️[server]: Server is running at http://localhost:${PORT}`);
+  logger.info(`⚡️ Event application listening on port ${PORT}`);
 });
 
 export default server;

--- a/application-templates/typescript/event/src/utils/config.utils.ts
+++ b/application-templates/typescript/event/src/utils/config.utils.ts
@@ -16,7 +16,6 @@ export const readConfiguration = () => {
     projectKey: process.env.CTP_PROJECT_KEY as string,
     scope: process.env.CTP_SCOPE,
     region: process.env.CTP_REGION as string,
-    port: process.env.PORT,
   };
 
   const validationErrors = getValidateMessages(envValidators, envVars);

--- a/application-templates/typescript/event/src/validators/env.validators.ts
+++ b/application-templates/typescript/event/src/validators/env.validators.ts
@@ -1,6 +1,5 @@
 import {
   optional,
-  standardNaturalNumber,
   standardString,
   standardKey,
   region,
@@ -49,12 +48,6 @@ const envValidators = [
   region(['region'], {
     code: 'InvalidRegion',
     message: 'Not a valid region.',
-    referencedBy: 'environmentVariables',
-  }),
-
-  optional(standardNaturalNumber)(['port'], {
-    code: 'InvalidPort',
-    message: 'Port is optional but should should be a number when provided.',
     referencedBy: 'environmentVariables',
   }),
 ];

--- a/application-templates/typescript/job/src/index.ts
+++ b/application-templates/typescript/job/src/index.ts
@@ -15,7 +15,7 @@ import { errorMiddleware } from './middleware/error.middleware';
 // Read env variables
 readConfiguration();
 
-const PORT = readConfiguration().port || 3000;
+const PORT = 8080;
 
 // Create the express app
 const app: Express = express();
@@ -28,7 +28,7 @@ app.use(errorMiddleware);
 
 // Listen the application
 const server = app.listen(PORT, () => {
-  logger.info(`⚡️[server]: Server is running at http://localhost:${PORT}`);
+  logger.info(`⚡️ Job application listening on port ${PORT}`);
 });
 
 export default server;

--- a/application-templates/typescript/job/src/utils/config.utils.ts
+++ b/application-templates/typescript/job/src/utils/config.utils.ts
@@ -16,7 +16,6 @@ export const readConfiguration = () => {
     projectKey: process.env.CTP_PROJECT_KEY as string,
     scope: process.env.CTP_SCOPE,
     region: process.env.CTP_REGION as string,
-    port: process.env.PORT,
   };
 
   const validationErrors = getValidateMessages(envValidators, envVars);

--- a/application-templates/typescript/job/src/validators/env.validators.ts
+++ b/application-templates/typescript/job/src/validators/env.validators.ts
@@ -1,6 +1,5 @@
 import {
   optional,
-  standardNaturalNumber,
   standardString,
   standardKey,
   region,
@@ -49,12 +48,6 @@ const envValidators = [
   region(['region'], {
     code: 'InvalidRegion',
     message: 'Not a valid region.',
-    referencedBy: 'environmentVariables',
-  }),
-
-  optional(standardNaturalNumber)(['port'], {
-    code: 'InvalidPort',
-    message: 'Port is optional but should should be a number when provided.',
     referencedBy: 'environmentVariables',
   }),
 ];

--- a/application-templates/typescript/service/src/index.ts
+++ b/application-templates/typescript/service/src/index.ts
@@ -15,7 +15,7 @@ import { errorMiddleware } from './middleware/error.middleware';
 // Read env variables
 readConfiguration();
 
-const PORT = readConfiguration().port || 3000;
+const PORT = 8080;
 
 // Create the express app
 const app: Express = express();
@@ -32,7 +32,7 @@ app.use(errorMiddleware);
 
 // Listen the application
 const server = app.listen(PORT, () => {
-  logger.info(`⚡️[server]: Server is running at http://localhost:${PORT}`);
+  logger.info(`⚡️ Service application listening on port ${PORT}`);
 });
 
 export default server;

--- a/application-templates/typescript/service/src/utils/config.utils.ts
+++ b/application-templates/typescript/service/src/utils/config.utils.ts
@@ -16,7 +16,6 @@ export const readConfiguration = () => {
     projectKey: process.env.CTP_PROJECT_KEY as string,
     scope: process.env.CTP_SCOPE,
     region: process.env.CTP_REGION as string,
-    port: process.env.PORT,
   };
 
   const validationErrors = getValidateMessages(envValidators, envVars);

--- a/application-templates/typescript/service/src/validators/env.validators.ts
+++ b/application-templates/typescript/service/src/validators/env.validators.ts
@@ -1,6 +1,5 @@
 import {
   optional,
-  standardNaturalNumber,
   standardString,
   standardKey,
   region,
@@ -49,12 +48,6 @@ const envValidators = [
   region(['region'], {
     code: 'InvalidRegion',
     message: 'Not a valid region.',
-    referencedBy: 'environmentVariables',
-  }),
-
-  optional(standardNaturalNumber)(['port'], {
-    code: 'InvalidPort',
-    message: 'Port is optional but should should be a number when provided.',
     referencedBy: 'environmentVariables',
   }),
 ];


### PR DESCRIPTION
## Link to the Jira issue
[IM-166] https://jira.commercetools.com/browse/IM-166

## Description and context
Remove the env PORT

## Instructions to build/test locally
<!-- Please include all necessary instructions for the reviewer to build, run and test your solution locally without any issues -->
For each application on each template (javascript/typescript), build and run it individually without the PORT env. Assert that the application is running on port 8080.

```bash
npm run build && npm run start
```

## Depends on another PR/branch?
<!-- Yes or no question. If so, identify the other PR/branch and what it depends on -->
- [x] No
- [ ] Yes - dependant on PR/branch: <!-- include a link to the related PR or branch -->

