### PR TITLE
fix: changed express import to solve 'can only be default-imported us…

### DIFF
--- a/application-templates/typescript/job/src/index.ts
+++ b/application-templates/typescript/job/src/index.ts
@@ -1,7 +1,8 @@
 import * as dotenv from 'dotenv';
 dotenv.config();
 
-import express, { Express } from 'express';
+import { Express } from 'express';
+import * as express from 'express';
 
 // Import routes
 import JobRoutes from './routes/job.route';


### PR DESCRIPTION
## Description and context
Fix: 
```
src/index.ts(4,8): error TS1259: Module '"C:/Workspace/kroschke/connect-application/job/node_modules/@types/express/index"' can only be default-imported using the 'esModuleInterop' flag
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief description of the solution
Changed way of import.

## How was it tested?
Just run ``yarn dev`` after fix and you won't get the error anymore.

## Instructions to build/test locally
Just run ``yarn dev`` after fix and you won't get the error anymore.

## Depends on another PR/branch?
<!-- Yes or no question. If so, identify the other PR/branch and what it depends on -->
- [x] No
- [ ] Yes - dependant on PR/branch: <!-- include a link to the related PR or branch -->

## Checklist- 
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [ ] I joined a screenshot of the app before and after the fix.

[upload the screenshot here]
