### PR TITLE
fix: fix package name in validation errors

### DIFF
--- a/packages/create-connect-app/src/validations.ts
+++ b/packages/create-connect-app/src/validations.ts
@@ -17,7 +17,7 @@ const throwIfTemplateIsNotSupported = (
     default: {
       const templateNamesList = Object.keys(availableTemplates).toString();
       throw new Error(
-        `The provided template name "${templateName}" does not exist. Available templates are "${templateNamesList}". Make sure you are also using the latest version of "@commercetools-frontend/create-mc-app".`
+        `The provided template name "${templateName}" does not exist. Available templates are "${templateNamesList}". Make sure you are also using the latest version of "@commercetools-frontend/create-connect-app".`
       );
     }
   }
@@ -42,7 +42,7 @@ const throwIfNodeVersionIsNotSupported = (
 
   if (!hasValidNodeVersion) {
     throw new Error(
-      `You are running Node ${currentNodeVersion} but create-mc-app requires Node ${expectedVersionRange}. Please update your version of Node.`
+      `You are running Node ${currentNodeVersion} but create-connect-app requires Node ${expectedVersionRange}. Please update your version of Node.`
     );
   }
 };


### PR DESCRIPTION
## Link to the Jira issue
<!-- Include a link to the Jira issue in []. This format is needed for the Jira integration to properly export the information to Jira -->
<!-- Example: [IM-18] https://jira.commercetools.com/browse/IM-18 -->
[IM-284] https://jira.commercetools.com/browse/IM-284

## Description and context
<!-- Bried description and context for the task. What's the motivation for it? -->
When throwing errors, we still had the previous package naming. Now changed to `create-connect-app`.

## Type of change
<!-- Please delete not relevant options -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist- 
- [x] No error nor warning in the console.