### PR TITLE
fix(templates): fix error handling and route method call

### DIFF
--- a/application-templates/javascript/event/src/routes/event.route.js
+++ b/application-templates/javascript/event/src/routes/event.route.js
@@ -5,12 +5,11 @@ import { post } from '../controllers/event.controller.js';
 
 const eventRouter = Router();
 
-eventRouter.post('/', async (req, res, next) => {
+eventRouter.post('/', (req, res, next) => {
   logger.info('Event message received');
   
   try {
-    await post(req.body);
-    res.status(200).send();
+    post(req, res);
   } catch (error) {
     next(error);
   }

--- a/application-templates/javascript/event/src/routes/event.route.js
+++ b/application-templates/javascript/event/src/routes/event.route.js
@@ -1,13 +1,19 @@
 import { Router } from 'express';
 
 import { logger } from '../utils/logger.utils.js';
+import { post } from '../controllers/event.controller.js';
 
 const eventRouter = Router();
 
-eventRouter.post('/', async (req, res) => {
+eventRouter.post('/', async (req, res, next) => {
   logger.info('Event message received');
-  res.status(200);
-  res.send();
+  
+  try {
+    await post(req.body);
+    res.status(200).send();
+  } catch (error) {
+    next(error);
+  }
 });
 
 export default eventRouter;

--- a/application-templates/javascript/job/src/routes/job.route.js
+++ b/application-templates/javascript/job/src/routes/job.route.js
@@ -5,10 +5,9 @@ import { post } from '../controllers/job.controller.js';
 // Create the router for our app
 const jobRouter = Router();
 
-jobRouter.post('/', async (req, res, next) => {
+jobRouter.post('/', (req, res, next) => {
   try {
-    await post(req, res);
-    res.status(200).send();
+    post(req, res);
   } catch (error) {
     next(error);
   }

--- a/application-templates/javascript/job/src/routes/job.route.js
+++ b/application-templates/javascript/job/src/routes/job.route.js
@@ -8,7 +8,7 @@ const jobRouter = Router();
 jobRouter.post('/', async (req, res, next) => {
   try {
     await post(req, res);
-    next();
+    res.status(200).send();
   } catch (error) {
     next(error);
   }

--- a/application-templates/javascript/service/src/routes/service.route.js
+++ b/application-templates/javascript/service/src/routes/service.route.js
@@ -4,13 +4,11 @@ import { post } from '../controllers/service.controller.js';
 
 const serviceRouter = Router();
 
-serviceRouter.post('/', async (req, res, next) => {
+serviceRouter.post('/', (req, res, next) => {
   logger.info('Cart update extension executed');
 
   try {
-    // Add your custom logic here
-    await post(req.body);
-    res.status(200).send();
+    post(req, res);
   } catch (error) {
     next(error);
   }

--- a/application-templates/javascript/service/src/routes/service.route.js
+++ b/application-templates/javascript/service/src/routes/service.route.js
@@ -1,12 +1,19 @@
 import { Router } from 'express';
 import { logger } from '../utils/logger.utils.js';
+import { post } from '../controllers/service.controller.js';
 
 const serviceRouter = Router();
 
-serviceRouter.post('/', async (req, res) => {
+serviceRouter.post('/', async (req, res, next) => {
   logger.info('Cart update extension executed');
-  res.status(200);
-  res.send();
+
+  try {
+    // Add your custom logic here
+    await post(req.body);
+    res.status(200).send();
+  } catch (error) {
+    next(error);
+  }
 });
 
 export default serviceRouter;

--- a/application-templates/typescript/event/src/routes/event.route.ts
+++ b/application-templates/typescript/event/src/routes/event.route.ts
@@ -1,13 +1,18 @@
 import { Router } from 'express';
 
 import { logger } from '../utils/logger.utils';
+import { post } from '../controllers/event.controller';
 
 const eventRouter: Router = Router();
 
-eventRouter.post('/', async (req, res) => {
+eventRouter.post('/', async (req, res, next) => {
   logger.info('Event message received');
-  res.status(200);
-  res.send();
+  try {
+    await post(req, res);
+    res.status(200).send();
+  } catch (error) {
+    next(error);
+  }
 });
 
 export default eventRouter;

--- a/application-templates/typescript/event/src/routes/event.route.ts
+++ b/application-templates/typescript/event/src/routes/event.route.ts
@@ -5,11 +5,10 @@ import { post } from '../controllers/event.controller';
 
 const eventRouter: Router = Router();
 
-eventRouter.post('/', async (req, res, next) => {
+eventRouter.post('/', (req, res, next) => {
   logger.info('Event message received');
   try {
-    await post(req, res);
-    res.status(200).send();
+    post(req, res);
   } catch (error) {
     next(error);
   }

--- a/application-templates/typescript/job/src/routes/job.route.ts
+++ b/application-templates/typescript/job/src/routes/job.route.ts
@@ -8,7 +8,7 @@ const jobRouter: Router = Router();
 jobRouter.post('/', async (req, res, next) => {
   try {
     await post(req, res);
-    next();
+    res.status(200).send();
   } catch (error) {
     next(error);
   }

--- a/application-templates/typescript/job/src/routes/job.route.ts
+++ b/application-templates/typescript/job/src/routes/job.route.ts
@@ -5,10 +5,9 @@ import { post } from '../controllers/job.controller';
 // Create the router for our app
 const jobRouter: Router = Router();
 
-jobRouter.post('/', async (req, res, next) => {
+jobRouter.post('/', (req, res, next) => {
   try {
-    await post(req, res);
-    res.status(200).send();
+    post(req, res);
   } catch (error) {
     next(error);
   }

--- a/application-templates/typescript/service/src/routes/service.route.ts
+++ b/application-templates/typescript/service/src/routes/service.route.ts
@@ -4,12 +4,11 @@ import { post } from '../controllers/service.controller';
 
 const serviceRouter = Router();
 
-serviceRouter.post('/', async (req, res, next) => {
+serviceRouter.post('/', (req, res, next) => {
   logger.info('Service post message received');
 
   try {
-    await post(req, res);
-    res.status(200).send();
+    post(req, res);
   } catch (error) {
     next(error); 
   }

--- a/application-templates/typescript/service/src/routes/service.route.ts
+++ b/application-templates/typescript/service/src/routes/service.route.ts
@@ -1,12 +1,18 @@
 import { Router } from 'express';
 import { logger } from '../utils/logger.utils';
+import { post } from '../controllers/service.controller';
 
 const serviceRouter = Router();
 
-serviceRouter.post('/', async (req, res) => {
-  logger.info('Cart update extension executed');
-  res.status(200);
-  res.send();
+serviceRouter.post('/', async (req, res, next) => {
+  logger.info('Service post message received');
+
+  try {
+    await post(req, res);
+    res.status(200).send();
+  } catch (error) {
+    next(error); 
+  }
 });
 
 export default serviceRouter;


### PR DESCRIPTION
## Link to the Jira issue
### This PR will englobe two tickets
[IM-1114](https://commercetools.atlassian.net/browse/IM-1114) and [IM-1117](https://commercetools.atlassian.net/browse/IM-1117)

## Description and context
Since the work was fairly straightforward, we used just one PR to fix both tickets. 

So, this PR will close #78 and close #80.

Assessing #78, a new implementation was introduced, as suggested, to call the next() function inside a `try-catch` block.
```
serviceRouter.post('/', async (req, res, next) => {
  logger.info('Service post message received');

  try {
    await post(req, res);
    res.status(200).send();
  } catch (error) {
    next(error);
  }
});
```
Regarding #80, the following files were updated to call the correct controller methods inside the routes.
```
- application-templates/javascript/event/src/routes/event.route.js
- application-templates/javascript/job/src/routes/job.route.js
- application-templates/javascript/service/src/routes/service.route.js

- application-templates/typescript/event/src/routes/event.route.ts
- application-templates/typescript/job/src/routes/job.route.ts
- application-templates/typescript/service/src/routes/service.route.ts
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


[IM-1114]: https://commercetools.atlassian.net/browse/IM-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IM-1117]: https://commercetools.atlassian.net/browse/IM-1117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ