### PR TITLE
Fixes/presales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ application-templates/**/yarn.lock
 application-templates/starter-typescript/job/.env
 application-templates/starter-typescript/job/.env.*
 !application-templates/starter-typescript/job/.env.example
+
+#IDE
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ application-templates/**/yarn.lock
 application-templates/starter-typescript/job/.env
 application-templates/starter-typescript/job/.env.*
 !application-templates/starter-typescript/job/.env.example
+application-templates/typescript/event/.env
+application-templates/typescript/event/.env.*
+!application-templates/typescript/event/.env.example
 
 #IDE
 .idea

--- a/application-templates/typescript/.gitignore
+++ b/application-templates/typescript/.gitignore
@@ -6,6 +6,7 @@ coverage
 
 .DS_Store
 .vscode
+.idea
 build/
 .env
 public/

--- a/application-templates/typescript/event/jest.config.cjs
+++ b/application-templates/typescript/event/jest.config.cjs
@@ -2,6 +2,8 @@ module.exports = {
   displayName: 'Tests Typescript Application - Event',
   moduleDirectories: ['node_modules', 'src'],
   testMatch: ['**/tests/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[tj]s?(x)'],
+  testPathIgnorePatterns: ['tests/setup-tests.ts'],
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/tests/setup-tests.ts'],
 };

--- a/application-templates/typescript/event/src/connector/actions.ts
+++ b/application-templates/typescript/event/src/connector/actions.ts
@@ -5,10 +5,9 @@ import {
 } from '@commercetools/platform-sdk';
 import { ByProjectKeyRequestBuilder } from '@commercetools/platform-sdk/dist/declarations/src/generated/client/by-project-key-request-builder';
 
-const CUSTOMER_CREATE_SUBSCRIPTION_KEY =
-  'myconnector-customerCreateSubscription';
+const SUBSCRIPTION_KEY = 'myconnector-customerCreateSubscription';
 
-export async function createGcpPubSubCustomerCreateSubscription(
+export async function createGcpPubSubSubscription(
   apiRoot: ByProjectKeyRequestBuilder,
   topicName: string,
   projectId: string
@@ -21,7 +20,7 @@ export async function createGcpPubSubCustomerCreateSubscription(
   await createSubscription(apiRoot, destination);
 }
 
-export async function createAzureServiceBusCustomerCreateSubscription(
+export async function createAzureServiceBusSubscription(
   apiRoot: ByProjectKeyRequestBuilder,
   connectionString: string
 ): Promise<void> {
@@ -36,12 +35,12 @@ async function createSubscription(
   apiRoot: ByProjectKeyRequestBuilder,
   destination: Destination
 ) {
-  await deleteCustomerCreateSubscription(apiRoot);
+  await deleteSubscription(apiRoot);
   await apiRoot
     .subscriptions()
     .post({
       body: {
-        key: CUSTOMER_CREATE_SUBSCRIPTION_KEY,
+        key: SUBSCRIPTION_KEY,
         destination,
         messages: [
           {
@@ -54,7 +53,7 @@ async function createSubscription(
     .execute();
 }
 
-export async function deleteCustomerCreateSubscription(
+export async function deleteSubscription(
   apiRoot: ByProjectKeyRequestBuilder
 ): Promise<void> {
   const {
@@ -63,7 +62,7 @@ export async function deleteCustomerCreateSubscription(
     .subscriptions()
     .get({
       queryArgs: {
-        where: `key = "${CUSTOMER_CREATE_SUBSCRIPTION_KEY}"`,
+        where: `key = "${SUBSCRIPTION_KEY}"`,
       },
     })
     .execute();
@@ -73,7 +72,7 @@ export async function deleteCustomerCreateSubscription(
 
     await apiRoot
       .subscriptions()
-      .withKey({ key: CUSTOMER_CREATE_SUBSCRIPTION_KEY })
+      .withKey({ key: SUBSCRIPTION_KEY })
       .delete({
         queryArgs: {
           version: subscription.version,

--- a/application-templates/typescript/event/src/connector/post-deploy.ts
+++ b/application-templates/typescript/event/src/connector/post-deploy.ts
@@ -4,8 +4,8 @@ dotenv.config();
 import { createApiRoot } from '../client/create.client';
 import { assertError, assertString } from '../utils/assert.utils';
 import {
-  createAzureServiceBusCustomerCreateSubscription,
-  createGcpPubSubCustomerCreateSubscription,
+  createAzureServiceBusSubscription,
+  createGcpPubSubSubscription,
 } from './actions';
 
 const CONNECT_GCP_TOPIC_NAME_KEY = 'CONNECT_GCP_TOPIC_NAME';
@@ -24,10 +24,7 @@ async function postDeploy(properties: Map<string, unknown>): Promise<void> {
         CONNECT_AZURE_CONNECTION_STRING_KEY
       );
       assertString(connectionString, CONNECT_AZURE_CONNECTION_STRING_KEY);
-      await createAzureServiceBusCustomerCreateSubscription(
-        apiRoot,
-        connectionString
-      );
+      await createAzureServiceBusSubscription(apiRoot, connectionString);
       break;
     }
     default: {
@@ -35,11 +32,7 @@ async function postDeploy(properties: Map<string, unknown>): Promise<void> {
       const projectId = properties.get(CONNECT_GCP_PROJECT_ID_KEY);
       assertString(topicName, CONNECT_GCP_TOPIC_NAME_KEY);
       assertString(projectId, CONNECT_GCP_PROJECT_ID_KEY);
-      await createGcpPubSubCustomerCreateSubscription(
-        apiRoot,
-        topicName,
-        projectId
-      );
+      await createGcpPubSubSubscription(apiRoot, topicName, projectId);
     }
   }
 }

--- a/application-templates/typescript/event/src/connector/pre-undeploy.ts
+++ b/application-templates/typescript/event/src/connector/pre-undeploy.ts
@@ -3,11 +3,11 @@ dotenv.config();
 
 import { createApiRoot } from '../client/create.client';
 import { assertError } from '../utils/assert.utils';
-import { deleteCustomerCreateSubscription } from './actions';
+import { deleteSubscription } from './actions';
 
 async function preUndeploy(): Promise<void> {
   const apiRoot = createApiRoot();
-  await deleteCustomerCreateSubscription(apiRoot);
+  await deleteSubscription(apiRoot);
 }
 
 async function run(): Promise<void> {

--- a/application-templates/typescript/event/src/controllers/event.controller.ts
+++ b/application-templates/typescript/event/src/controllers/event.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { createApiRoot } from '../client/create.client';
 import CustomError from '../errors/custom.error';
 import { logger } from '../utils/logger.utils';
+import { Message } from '@commercetools/platform-sdk';
 
 /**
  * Exposed event POST endpoint.
@@ -36,9 +37,13 @@ export const post = async (request: Request, response: Response) => {
     : undefined;
 
   if (decodedData) {
-    const jsonData = JSON.parse(decodedData);
+    const jsonData: Message | null = JSON.parse(decodedData);
 
-    customerId = jsonData.customer.id;
+    if (jsonData) {
+      if (jsonData.type === 'CustomerCreated') {
+        customerId = jsonData.customer.id;
+      }
+    }
   }
 
   if (!customerId) {

--- a/application-templates/typescript/event/tests/integration/event.spec.ts
+++ b/application-templates/typescript/event/tests/integration/event.spec.ts
@@ -67,7 +67,7 @@ describe('Testing Event Controller', () => {
   });
 
   /*
-   * This Test really want to call the commercetools APIs. To do so,
+   * This Test really calls the commercetools APIs. To do so,
    * - remove the mocking code in line 7-12
    * - configure a "real" customerId
    * - remove the skip below

--- a/application-templates/typescript/event/tests/integration/event.spec.ts
+++ b/application-templates/typescript/event/tests/integration/event.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect } from '@jest/globals';
+import { CustomerCreatedMessage, Customer } from '@commercetools/platform-sdk';
+import request from 'supertest';
+import app from '../../src/app';
+import { createApiRoot } from '../../src/client/create.client';
+
+jest.mock('../../src/client/create.client', () => {
+  const mockCreateApiRoot = jest.fn();
+  return {
+    createApiRoot: mockCreateApiRoot,
+  };
+});
+
+const customerId = 'd93a8493-1bfd-4e2d-8b46-20a765dd0978';
+
+const customer: Customer = {
+  id: customerId,
+  createdAt: '',
+  lastModifiedAt: '',
+  version: 0,
+  email: '',
+  isEmailVerified: true,
+  addresses: [],
+  authenticationMode: 'Password',
+};
+
+const orderCreatedMessage: CustomerCreatedMessage = {
+  createdAt: '',
+  id: '',
+  lastModifiedAt: '',
+  resource: { id: customerId, typeId: 'customer' },
+  resourceVersion: 0,
+  sequenceNumber: 0,
+  type: 'CustomerCreated',
+  version: 0,
+  customer: customer,
+};
+
+describe('Testing Event Controller', () => {
+  it('Customer Created (Mocked)', async () => {
+    // Define a mock root to be returned
+    const withId = jest.fn().mockReturnValueOnce({
+      get: jest.fn().mockReturnValueOnce({
+        execute: jest.fn().mockReturnValueOnce(customer),
+      }),
+    });
+    const mockRoot = {
+      customers: jest.fn().mockReturnValueOnce({
+        withId: withId,
+      }),
+    };
+
+    // Set the mock implementation for createApiRoot to return mockRoot
+    (createApiRoot as jest.Mock).mockReturnValueOnce(mockRoot);
+
+    const response = await request(app)
+      .post('/event')
+      .send({
+        message: {
+          data: Buffer.from(JSON.stringify(orderCreatedMessage)).toString(
+            'base64'
+          ),
+        },
+      });
+    expect(response.status).toBe(204);
+    expect(withId).toHaveBeenCalledWith({ ID: customerId });
+  });
+
+  /*
+   * This Test really want to call the commercetools APIs. To do so,
+   * - remove the mocking code in line 7-12
+   * - configure a "real" customerId
+   * - remove the skip below
+   *
+   * The code below comes in handy to test during development.
+   */
+  it.skip('Customer Created', async () => {
+    const response = await request(app)
+      .post('/event')
+      .send({
+        message: {
+          data: Buffer.from(JSON.stringify(orderCreatedMessage)).toString(
+            'base64'
+          ),
+        },
+      });
+    expect(response.status).toBe(204);
+  });
+});

--- a/application-templates/typescript/event/tests/setup-tests.ts
+++ b/application-templates/typescript/event/tests/setup-tests.ts
@@ -1,0 +1,3 @@
+import { config } from 'dotenv';
+config();
+config({ path: `.env.local`, override: true });

--- a/application-templates/typescript/event/tsconfig.json
+++ b/application-templates/typescript/event/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
-  "exclude": ["node_modules", "**/*.spec.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts", "**/setup-tests.ts"],
   "compilerOptions": {
     "resolveJsonModule": true,
     "outDir": "./build",


### PR DESCRIPTION
## Description and context
We are using the template in presales a lot to show how easy it is to build events using connect. What we need to do so is a rapid development roundtrip. We achieve this by writing tests using them to e.g. trigger a customer created message.

## Type of change
- [ ] New feature

## Brief description of the solution
 IDEs like idea allow you to run tests right from within the IDE, taking away the pain of doing things e.g. via postman. On top the message payload is also versioned within git.
