### PR TITLE
Post size of event

### DIFF
--- a/application-templates/javascript/event/src/app.js
+++ b/application-templates/javascript/event/src/app.js
@@ -18,8 +18,8 @@ const app = express();
 app.disable('x-powered-by');
 
 // Define configurations
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json({ limit: '5mb' }));
+app.use(bodyParser.urlencoded({ extended: true, limit: '5mb' }));
 
 // Define routes
 app.use('/event', EventRoutes);

--- a/application-templates/typescript/event/src/app.ts
+++ b/application-templates/typescript/event/src/app.ts
@@ -19,8 +19,8 @@ const app: Express = express();
 app.disable('x-powered-by');
 
 // Define configurations
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json({ limit: '5mb' }));
+app.use(bodyParser.urlencoded({ extended: true, limit: '5mb' }));
 
 // Define routes
 app.use('/event', EventRoutes);


### PR DESCRIPTION
## Express default to 100Kb post size but event messages can be larger than that

Reported in [this support issue](https://commercetools.atlassian.net/browse/SUPPORT-37617)

