### PR TITLE
feat: document optional healthCheck in connect.yaml templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ deployAs:
   - name: app1
     applicationType: service
     endpoint: /app1
+    healthCheck:
+      path: /health
+      intervalSeconds: 10
+      timeoutSeconds: 5
+      unhealthyThreshold: 3
     scripts:
       postDeploy: npm install && npm run build && npm run connector:post-deploy
       preUndeploy: npm install && npm run build && npm run connector:pre-undeploy
@@ -171,6 +176,11 @@ deployAs:
 - `name` - Folder name of respective application component from the root of monorepo which will be used as identifier of the application. Deployment output url, topic & schedule can be fetched based on this reference
 - `applicationType` - Type of deployment . Can be one of `service`, `event`, `job` and `merchant-center-custom-application`
 - `endpoint` - Point of entry for respective application component
+- `healthCheck` - Optional HTTP health check for `service` and `event` applications. When omitted, the platform uses a default check that only verifies the container is listening on its port. When set, the application is polled over HTTP and unhealthy instances are replaced.
+  - `healthCheck.path` - HTTP path polled for the health check (for example `/health`). Required when `healthCheck` is set
+  - `healthCheck.intervalSeconds` - Optional interval between checks, between 1 and 20 seconds
+  - `healthCheck.timeoutSeconds` - Optional timeout for each check, between 1 and 20 seconds
+  - `healthCheck.unhealthyThreshold` - Optional number of consecutive failures before an instance is considered unhealthy, between 1 and 20
 - `scripts.postDeploy` - Post-deploy script to execute after the connector deployment process
 - `scripts.preUndeploy` - Pre-undeploy script to execute before the connector undeployment process
 - `configuration` - Definiton of all environment variables needed by the application, customer will be responsible to provide value for these variables when choosen to deploy. You need to choose between `standardConfiguration` and `securedConfiguration`. `standardConfiguration` for customer provided values to be saved as plain text , `securedConfiguration` for customer provided values to be secured and stored in encrypted format. configurations can be marked `required` depending on application implementation and also provided a `default` value if needed

--- a/application-templates/javascript/connect.yaml
+++ b/application-templates/javascript/connect.yaml
@@ -4,6 +4,11 @@ deployAs:
   - name: service
     applicationType: service
     endpoint: /service
+    healthCheck:
+      path: /health
+      intervalSeconds: 10
+      timeoutSeconds: 5
+      unhealthyThreshold: 3
     scripts:
       postDeploy: npm install && npm run connector:post-deploy
       preUndeploy: npm install && npm run connector:pre-undeploy
@@ -53,6 +58,11 @@ deployAs:
   - name: event
     applicationType: event
     endpoint: /event
+    healthCheck:
+      path: /health
+      intervalSeconds: 10
+      timeoutSeconds: 5
+      unhealthyThreshold: 3
     scripts:
       postDeploy: npm install && npm run connector:post-deploy
       preUndeploy: npm install && npm run connector:pre-undeploy

--- a/application-templates/typescript/connect.yaml
+++ b/application-templates/typescript/connect.yaml
@@ -4,6 +4,11 @@ deployAs:
   - name: service
     applicationType: service
     endpoint: /service
+    healthCheck:
+      path: /health
+      intervalSeconds: 10
+      timeoutSeconds: 5
+      unhealthyThreshold: 3
     scripts:
       postDeploy: npm install && npm run build && npm run connector:post-deploy
       preUndeploy: npm install && npm run build && npm run connector:pre-undeploy
@@ -53,6 +58,11 @@ deployAs:
   - name: event
     applicationType: event
     endpoint: /event
+    healthCheck:
+      path: /health
+      intervalSeconds: 10
+      timeoutSeconds: 5
+      unhealthyThreshold: 3
     scripts:
       postDeploy: npm install && npm run build && npm run connector:post-deploy
       preUndeploy: npm install && npm run build && npm run connector:pre-undeploy


### PR DESCRIPTION
## Description and context

Part of the connector HTTP health-check feature. This updates the author-facing starter templates and documentation so connector developers know how to declare an optional HTTP `healthCheck` in `connect.yaml`.

The full cross-repo context lives in the **connect-services** PR (linked in a comment below).

## Brief description of the solution

- Added an example `healthCheck` block to the `service` and `event` applications in both the JavaScript and TypeScript `connect.yaml` templates.
- Documented the `healthCheck` property and its fields (`path`, `intervalSeconds`, `timeoutSeconds`, `unhealthyThreshold`) in the README, including in the sample `connect.yaml`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How was it tested?

- [x] Manual review of the rendered templates and README; the `healthCheck` shape matches the schema enforced by the specification package and the deployment pipeline.

## Depends on another PR/branch?

- [x] Yes — depends on the schema/pipeline changes in the connect-services PR (linked in a comment below).