### PR TITLE
feat: add probes.liveness/startup to connect.yaml application templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,12 @@ deployAs:
 - `scripts.preUndeploy` - Pre-undeploy script to execute before the connector undeployment process
 - `configuration` - Definiton of all environment variables needed by the application, customer will be responsible to provide value for these variables when choosen to deploy. You need to choose between `standardConfiguration` and `securedConfiguration`. `standardConfiguration` for customer provided values to be saved as plain text , `securedConfiguration` for customer provided values to be secured and stored in encrypted format. configurations can be marked `required` depending on application implementation and also provided a `default` value if needed
 - `schedule` - Schedule expression for job applications, it need to be input of type <a href="https://en.wikipedia.org/wiki/Cron">cron</a> expression
+- `probes` - Optional HTTP health probes for `service` and `event` applications. Not supported on `job` or `merchant-center-custom-application` types.
+  - `probes.liveness` - Periodic HTTP liveness check. Supported on **GCP Cloud Run** and **AWS App Runner**. Requires `path` (the HTTP endpoint to probe); all other fields are optional and accept integer values from 1–20:
+    - `path` - HTTP path for the liveness probe (e.g. `/health`)
+    - `intervalSeconds` - How often the probe runs (seconds)
+    - `timeoutSeconds` - Probe request timeout (seconds)
+    - `unhealthyThreshold` - Consecutive failures before the instance is considered unhealthy
+    - `healthyThreshold` - Consecutive successes to return to healthy; ignored on GCP Cloud Run (AWS App Runner only)
+  - `probes.startup` - One-shot startup gate checked once before the first liveness probe. Supported on **GCP Cloud Run only**; silently ignored on AWS App Runner deployments. Requires `path`; accepts the same optional numeric fields as `liveness` except `healthyThreshold` (not applicable to a one-shot gate).
+  - At least one of `liveness` or `startup` must be defined when `probes` is present.

--- a/application-templates/javascript/connect.yaml
+++ b/application-templates/javascript/connect.yaml
@@ -7,6 +7,22 @@ deployAs:
     scripts:
       postDeploy: npm install && npm run connector:post-deploy
       preUndeploy: npm install && npm run connector:pre-undeploy
+    # Optional: HTTP health probes for service and event applications.
+    # probes.liveness — periodic HTTP check on GCP Cloud Run and AWS App Runner.
+    # probes.startup  — one-shot startup gate on GCP Cloud Run only; silently
+    #                   ignored on AWS App Runner (which has no startup concept).
+    # All numeric fields are optional and range from 1–20.
+    # probes:
+    #   liveness:
+    #     path: /health          # required if liveness is declared
+    #     intervalSeconds: 10
+    #     timeoutSeconds: 5
+    #     unhealthyThreshold: 3
+    #     healthyThreshold: 1    # AWS App Runner only; ignored on GCP
+    #   startup:
+    #     path: /ready           # required if startup is declared
+    #     intervalSeconds: 10
+    #     unhealthyThreshold: 12
     configuration:
       standardConfiguration:
         - key: CTP_REGION
@@ -56,6 +72,10 @@ deployAs:
     scripts:
       postDeploy: npm install && npm run connector:post-deploy
       preUndeploy: npm install && npm run connector:pre-undeploy
+    # Optional: same probes structure as service; see service section above.
+    # probes:
+    #   liveness:
+    #     path: /health
     configuration:
       standardConfiguration:
         - key: CTP_REGION

--- a/application-templates/typescript/connect.yaml
+++ b/application-templates/typescript/connect.yaml
@@ -7,6 +7,22 @@ deployAs:
     scripts:
       postDeploy: npm install && npm run build && npm run connector:post-deploy
       preUndeploy: npm install && npm run build && npm run connector:pre-undeploy
+    # Optional: HTTP health probes for service and event applications.
+    # probes.liveness — periodic HTTP check on GCP Cloud Run and AWS App Runner.
+    # probes.startup  — one-shot startup gate on GCP Cloud Run only; silently
+    #                   ignored on AWS App Runner (which has no startup concept).
+    # All numeric fields are optional and range from 1–20.
+    # probes:
+    #   liveness:
+    #     path: /health          # required if liveness is declared
+    #     intervalSeconds: 10
+    #     timeoutSeconds: 5
+    #     unhealthyThreshold: 3
+    #     healthyThreshold: 1    # AWS App Runner only; ignored on GCP
+    #   startup:
+    #     path: /ready           # required if startup is declared
+    #     intervalSeconds: 10
+    #     unhealthyThreshold: 12
     configuration:
       standardConfiguration:
         - key: CTP_REGION
@@ -56,6 +72,10 @@ deployAs:
     scripts:
       postDeploy: npm install && npm run build && npm run connector:post-deploy
       preUndeploy: npm install && npm run build && npm run connector:pre-undeploy
+    # Optional: same probes structure as service; see service section above.
+    # probes:
+    #   liveness:
+    #     path: /health
     configuration:
       standardConfiguration:
         - key: CTP_REGION


### PR DESCRIPTION
## Summary

Adds commented-out `probes` configuration examples to the `service` and `event` application blocks in both the TypeScript and JavaScript connect.yaml templates, and documents the new `probes` property in the README.

**Original PR:** #99

---

## What changed

### `application-templates/typescript/connect.yaml` and `application-templates/javascript/connect.yaml`

The `service` application block now includes a fully annotated (but commented-out) `probes` example showing both `liveness` and `startup` probes with inline notes on platform support:

```yaml
# probes:
#   liveness:
#     path: /health          # required if liveness is declared
#     intervalSeconds: 10
#     timeoutSeconds: 5
#     unhealthyThreshold: 3
#     healthyThreshold: 1    # AWS App Runner only; ignored on GCP
#   startup:
#     path: /ready           # required if startup is declared
#     intervalSeconds: 10
#     unhealthyThreshold: 12
```

The `event` application block includes a minimal commented `probes` stub with a pointer to the `service` section for the full syntax.

### `README.md`

The **Property definition** section now documents:
- `probes` — top-level optional property on `service`/`event` applications
- `probes.liveness` — periodic HTTP check on GCP Cloud Run and AWS App Runner; all fields described
- `probes.startup` — GCP Cloud Run only, silently ignored on AWS App Runner; fields described including why `healthyThreshold` is absent

---

## Platform behaviour

| Probe | GCP Cloud Run | AWS App Runner |
|---|---|---|
| `probes.liveness` | ✅ periodic HTTP check | ✅ periodic HTTP check |
| `probes.startup` | ✅ one-shot startup gate | ⚠️ silently ignored |
| `healthyThreshold` | ⚠️ silently ignored | ✅ supported |

---

## Related PRs

- connect-services: commercetools/connect-services#2074
- CLI: commercetools/cli#311
- connect-application-kit (original): #99

---

## Staged release

This PR carries documentation changes only and ships through the normal staged release process (dev → stage → prod) alongside the connect-services and CLI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)